### PR TITLE
Create task details page and implement add task feature

### DIFF
--- a/LiveSchedClient/pom.xml
+++ b/LiveSchedClient/pom.xml
@@ -48,6 +48,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.15.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/LiveSchedClient/src/main/java/dev/coms4156/project/liveschedclient/LiveSchedService.java
+++ b/LiveSchedClient/src/main/java/dev/coms4156/project/liveschedclient/LiveSchedService.java
@@ -3,13 +3,16 @@ package dev.coms4156.project.liveschedclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
@@ -26,7 +29,8 @@ public class LiveSchedService {
   // Change BASE_URL to "https://innov8-livesched.ue.r.appspot.com" after deployment;
   private static final String BASE_URL = "http://localhost:8080";
 
-  private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
   /**
    * Constructor to initialize the RestTemplate for making HTTP requests.
@@ -34,7 +38,14 @@ public class LiveSchedService {
    * @param restTemplateBuilder A builder for creating RestTemplate instances.
    */
   public LiveSchedService(RestTemplateBuilder restTemplateBuilder) {
-    this.restTemplate = restTemplateBuilder.build();
+    // Use Apache HttpClient for PATCH requests
+    CloseableHttpClient httpClient = HttpClients.createDefault();
+    HttpComponentsClientHttpRequestFactory requestFactory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+
+    this.restTemplate = restTemplateBuilder
+        .requestFactory(() -> requestFactory)
+        .build();
   }
 
   /**
@@ -88,8 +99,7 @@ public class LiveSchedService {
   public Map<String, Object> getTaskById(String taskId) {
     try {
       ResponseEntity<String> response = restTemplate.getForEntity(
-          BASE_URL + "/retrieveTask?taskId=" + taskId, String.class
-      );
+          BASE_URL + "/retrieveTask?taskId=" + taskId, String.class);
 
       if (response.getStatusCode().is2xxSuccessful()) {
         ObjectMapper mapper = new ObjectMapper();
@@ -122,6 +132,40 @@ public class LiveSchedService {
     }
     if (endTime != null) {
       task.put("endTime", LocalDateTime.parse(endTime).format(FORMATTER));
+    }
+  }
+
+  /**
+   * Adds a new task to the server's database through the addTask endpoint.
+   *
+   * @param taskName  The name of the task.
+   * @param priority  The priority of the task (1-5).
+   * @param startTime The start time of the task in the format "yyyy-MM-dd HH:mm".
+   * @param endTime   The end time of the task in the format "yyyy-MM-dd HH:mm".
+   * @param latitude  The latitude of the task's location.
+   * @param longitude The longitude of the task's location.
+   * @return A message indicating the response from the server.
+   */
+  public Map<String, Object> addTask(String taskName, int priority, String startTime,
+                                     String endTime, double latitude, double longitude) {
+    try {
+      ResponseEntity<String> response = restTemplate.exchange(
+          BASE_URL + "/addTask?taskName=" + taskName
+              + "&priority=" + priority
+              + "&startTime=" + startTime
+              + "&endTime=" + endTime
+              + "&latitude=" + latitude
+              + "&longitude=" + longitude,
+          HttpMethod.PATCH, null, String.class);
+
+      if (response.getStatusCode().is2xxSuccessful()) {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(response.getBody(), new TypeReference<>() {});
+      } else {
+        return Map.of("error", "Unexpected response status: " + response.getStatusCode());
+      }
+    } catch (Exception e) {
+      return Map.of("error", "Failed to add task");
     }
   }
 

--- a/LiveSchedClient/src/main/java/dev/coms4156/project/liveschedclient/MainController.java
+++ b/LiveSchedClient/src/main/java/dev/coms4156/project/liveschedclient/MainController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -42,8 +43,11 @@ public class MainController {
   /**
    * Handles requests to the dashboard page.
    * Retrieves tasks from the LiveSched service and adds them to the model for rendering.
+   * Allows searching for a task by its ID and sorting tasks by priority.
    *
-   * @param model The Model object used to pass data to the view.
+   * @param taskId Optional.   The ID of the task to search for.
+   * @param sort Optional.     The sort order for tasks, either {@code "asc"} or {@code "desc"}.
+   * @param model              The Model object used to pass data to the view.
    * @return A String containing the name of the HTML file to render the dashboard.
    */
   @GetMapping("/dashboard")
@@ -59,7 +63,7 @@ public class MainController {
       Map<String, Object> task = liveSchedService.getTaskById(taskId);
       if (task.containsKey("error")) {
         model.addAttribute("message", task.get("error"));
-        return "dashboard";
+        return "dashboard"; // Redirect back to task dashboard with error message
       } else {
         tasks = List.of(task);
       }
@@ -81,6 +85,26 @@ public class MainController {
 
     model.addAttribute("tasks", tasks);
     return "dashboard";
+  }
+
+  /**
+   * Displays the details of a specific task.
+   *
+   * @param taskId The ID of the task to display.
+   * @param model  The Model object used to pass data to the view.
+   * @return A String containing the name of the HTML file to render the task detail page.
+   */
+  @GetMapping("/task/{taskId}")
+  public String taskDetail(@PathVariable String taskId, Model model) {
+    Map<String, Object> task = liveSchedService.getTaskById(taskId);
+
+    if (task.containsKey("error")) {
+      model.addAttribute("message", task.get("error"));
+      return "dashboard"; // Redirect back to task dashboard with error message
+    }
+
+    model.addAttribute("task", task);
+    return "taskDetail";
   }
 
 }

--- a/LiveSchedClient/src/main/java/dev/coms4156/project/liveschedclient/MainController.java
+++ b/LiveSchedClient/src/main/java/dev/coms4156/project/liveschedclient/MainController.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -29,7 +30,7 @@ public class MainController {
   }
 
   /**
-   * Handles requests to the homepage.
+   * Displays the homepage.
    * Calls the server's index API to establish a connection.
    *
    * @return A String containing the name of the HTML file to render the homepage.
@@ -41,8 +42,7 @@ public class MainController {
   }
 
   /**
-   * Handles requests to the dashboard page.
-   * Retrieves tasks from the LiveSched service and adds them to the model for rendering.
+   * Displays the task dashboard page.
    * Allows searching for a task by its ID and sorting tasks by priority.
    *
    * @param taskId Optional.   The ID of the task to search for.
@@ -51,11 +51,9 @@ public class MainController {
    * @return A String containing the name of the HTML file to render the dashboard.
    */
   @GetMapping("/dashboard")
-  public String dashboard(
-      @RequestParam(value = "taskId", required = false) String taskId,
-      @RequestParam(value = "sort", required = false) String sort,
-      Model model
-  ) {
+  public String dashboard(@RequestParam(value = "taskId", required = false) String taskId,
+                          @RequestParam(value = "sort", required = false) String sort,
+                          Model model) {
     List<Map<String, Object>> tasks;
 
     if (taskId != null && !taskId.isBlank()) {
@@ -105,6 +103,47 @@ public class MainController {
 
     model.addAttribute("task", task);
     return "taskDetail";
+  }
+
+  /**
+   * Displays the page for adding a new task.
+   *
+   * @return A String containing the name of the HTML file to render the add task page.
+   */
+  @GetMapping("/task/add")
+  public String addTask() {
+    return "addTask";
+  }
+
+  /**
+   * Handles the submission of the new task form.
+   *
+   * @param taskName  The name of the task.
+   * @param priority  The priority of the task (1-5).
+   * @param startTime The start time of the task in the format "yyyy-MM-dd HH:mm".
+   * @param endTime   The end time of the task in the format "yyyy-MM-dd HH:mm".
+   * @param latitude  The latitude of the task's location.
+   * @param longitude The longitude of the task's location.
+   * @param model     The Model object used to pass data to the view.
+   * @return A String containing the name of the HTML file to render:
+   *         - If the task is added successfully, redirects to the new task's detail page.
+   *         - If an error occurs, returns to the add task page with the error message.
+   */
+  @PostMapping("/task/add")
+  public String addTask(@RequestParam(value = "taskName") String taskName,
+                        @RequestParam(value = "priority") int priority,
+                        @RequestParam(value = "startTime") String startTime,
+                        @RequestParam(value = "endTime") String endTime,
+                        @RequestParam(value = "latitude") double latitude,
+                        @RequestParam(value = "longitude") double longitude,
+                        Model model) {
+    Map<String, Object> newTask =
+        liveSchedService.addTask(taskName, priority, startTime, endTime, latitude, longitude);
+    if (newTask.containsKey("error")) {
+      model.addAttribute("message", newTask.get("error"));
+      return "addTask"; // Stay on the addTask page with the error message
+    }
+    return "redirect:/task/" + newTask.get("taskId"); // Redirect to the new task's page
   }
 
 }

--- a/LiveSchedClient/src/main/resources/templates/addTask.html
+++ b/LiveSchedClient/src/main/resources/templates/addTask.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LiveSched - Add New Task</title>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+    <div class="container mt-5">
+        <h1 class="mb-3">Add New Task</h1>
+
+        <!-- Error Message -->
+        <p th:if="${message}" th:text="${message}" class="text-danger"></p>
+
+        <!-- Add Task Form -->
+        <form method="post" action="/task/add">
+          <div class="form-group">
+            <label for="taskName">Task Name</label>
+            <input type="text" class="form-control" id="taskName" name="taskName" required>
+          </div>
+          <div class="form-group">
+            <label for="priority">Priority (1 = Most Important, 5 = Least Important)</label>
+            <input type="number" class="form-control" id="priority" name="priority" min="1" max="5" required>
+          </div>
+          <div class="form-group">
+            <label for="startTime">Start Time (yyyy-MM-dd HH:mm)</label>
+            <input type="text" class="form-control" id="startTime" name="startTime" required>
+          </div>
+          <div class="form-group">
+            <label for="endTime">End Time (yyyy-MM-dd HH:mm)</label>
+            <input type="text" class="form-control" id="endTime" name="endTime" required>
+          </div>
+          <div class="form-group">
+            <label for="latitude">Latitude</label>
+            <input type="number" step="0.000001" class="form-control" id="latitude" name="latitude" required>
+          </div>
+          <div class="form-group">
+            <label for="longitude">Longitude</label>
+            <input type="number" step="0.000001" class="form-control" id="longitude" name="longitude" required>
+          </div>
+          <div class="form-group d-flex justify-content-between">
+            <button type="submit" class="btn btn-primary">Submit</button>
+            <a href="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
+          </div>
+      </form>
+    </div>
+</body>
+</html>

--- a/LiveSchedClient/src/main/resources/templates/dashboard.html
+++ b/LiveSchedClient/src/main/resources/templates/dashboard.html
@@ -4,15 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>LiveSched - Task Dashboard</title>
-    <link
-            href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-            rel="stylesheet"
-    />
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet"/>
     <style>
         h1 {
             margin: 20px;
             text-align: center;
             color: #333;
+        }
+
+        tr[data-href] {
+            cursor: pointer;
+        }
+
+        tr[data-href]:hover {
+            background-color: #f5f5f5;
         }
     </style>
 </head>
@@ -45,7 +50,7 @@
     <p th:if="${message}" th:text="${message}" class="text-danger"></p>
 
     <!-- Task Table -->
-    <table class="table table-bordered table-striped" th:if="${tasks}">
+    <table class="table table-bordered" th:if="${tasks}">
         <thead class="thead-dark">
         <tr>
             <th>Task ID</th>
@@ -53,17 +58,15 @@
             <th>Priority</th>
             <th>Start Time</th>
             <th>End Time</th>
-            <th>Location Coordinates</th>
         </tr>
         </thead>
         <tbody>
-        <tr th:each="task : ${tasks}">
+        <tr th:each="task : ${tasks}" th:attr="data-href='/task/' + ${task['taskId']}" onclick="window.location=this.getAttribute('data-href')">
             <td th:text="${task['taskId']}"></td>
             <td th:text="${task['taskName']}"></td>
             <td th:text="${task['priority']}"></td>
-            <td th:text="${task['startTime'].substring(0, 16)}"></td>
-            <td th:text="${task['endTime'].substring(0, 16)}"></td>
-            <td th:text="${task['location']['coordinates']}"></td>
+            <td th:text="${task['startTime']}"></td>
+            <td th:text="${task['endTime']}"></td>
         </tr>
         </tbody>
     </table>

--- a/LiveSchedClient/src/main/resources/templates/dashboard.html
+++ b/LiveSchedClient/src/main/resources/templates/dashboard.html
@@ -22,54 +22,59 @@
     </style>
 </head>
 <body>
-<h1>Task Dashboard</h1>
-<div class="container mt-5">
-    <!-- Search and Sort -->
-    <form method="get" action="/dashboard" class="form-inline mb-3">
-        <div class="form-group mr-3">
-            <input
-                    type="text"
-                    name="taskId"
-                    placeholder="Search by Task ID"
-                    class="form-control"
-            />
-        </div>
-        <div class="form-group mr-3">
-            <select name="sort" class="form-control">
-                <option value="" disabled selected>Sort by Priority</option>
-                <option value="asc">Highest Priority First</option>
-                <option value="desc">Lowest Priority First</option>
-            </select>
-        </div>
-        <div class="form-group mr-3">
-            <button type="submit" class="btn btn-primary">Search/Sort</button>
-        </div>
-    </form>
+    <h1>Task Dashboard</h1>
+    <div class="container mt-5">
+        <div class="d-flex justify-content-between mb-3">
+            <!-- Search and Sort -->
+            <form method="get" action="/dashboard" class="form-inline">
+                <div class="form-group mr-3">
+                    <input
+                            type="text"
+                            name="taskId"
+                            placeholder="Search by Task ID"
+                            class="form-control"
+                    />
+                </div>
+                <div class="form-group mr-3">
+                    <select name="sort" class="form-control">
+                        <option value="" disabled selected>Sort by Priority</option>
+                        <option value="asc">Highest Priority First</option>
+                        <option value="desc">Lowest Priority First</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <button type="submit" class="btn btn-primary">Search/Sort</button>
+                </div>
+            </form>
 
-    <!-- Error Message -->
-    <p th:if="${message}" th:text="${message}" class="text-danger"></p>
+            <!-- Add Task Button -->
+            <a href="/task/add" class="btn btn-success">Add New Task</a>
+        </div>
 
-    <!-- Task Table -->
-    <table class="table table-bordered" th:if="${tasks}">
-        <thead class="thead-dark">
-        <tr>
-            <th>Task ID</th>
-            <th>Task Name</th>
-            <th>Priority</th>
-            <th>Start Time</th>
-            <th>End Time</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="task : ${tasks}" th:attr="data-href='/task/' + ${task['taskId']}" onclick="window.location=this.getAttribute('data-href')">
-            <td th:text="${task['taskId']}"></td>
-            <td th:text="${task['taskName']}"></td>
-            <td th:text="${task['priority']}"></td>
-            <td th:text="${task['startTime']}"></td>
-            <td th:text="${task['endTime']}"></td>
-        </tr>
-        </tbody>
-    </table>
-</div>
+        <!-- Error Message -->
+        <p th:if="${message}" th:text="${message}" class="text-danger"></p>
+
+        <!-- Task Table -->
+        <table class="table table-bordered" th:if="${tasks}">
+            <thead class="thead-dark">
+            <tr>
+                <th>Task ID</th>
+                <th>Task Name</th>
+                <th>Priority</th>
+                <th>Start Time</th>
+                <th>End Time</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="task : ${tasks}" th:attr="data-href='/task/' + ${task['taskId']}" onclick="window.location=this.getAttribute('data-href')">
+                <td th:text="${task['taskId']}"></td>
+                <td th:text="${task['taskName']}"></td>
+                <td th:text="${task['priority']}"></td>
+                <td th:text="${task['startTime']}"></td>
+                <td th:text="${task['endTime']}"></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
 </body>
 </html>

--- a/LiveSchedClient/src/main/resources/templates/taskDetail.html
+++ b/LiveSchedClient/src/main/resources/templates/taskDetail.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LiveSched - Task Details</title>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+<div class="container mt-5">
+    <h1>Task Details</h1>
+    <table class="table table-bordered">
+        <tbody>
+        <tr>
+            <th>Task ID</th>
+            <td th:text="${task['taskId']}"></td>
+        </tr>
+        <tr>
+            <th>Task Name</th>
+            <td th:text="${task['taskName']}"></td>
+        </tr>
+        <tr>
+            <th>Priority</th>
+            <td th:text="${task['priority']}"></td>
+        </tr>
+        <tr>
+            <th>Start Time</th>
+            <td th:text="${task['startTime'].substring(0, 16)}"></td>
+        </tr>
+        <tr>
+            <th>End Time</th>
+            <td th:text="${task['endTime'].substring(0, 16)}"></td>
+        </tr>
+        <tr>
+            <th>Location</th>
+            <td th:text="${task['location']['coordinates']}"></td>
+        </tr>
+        <tr>
+            <th>Resources Needed</th>
+            <td>
+                <ul>
+                    <li th:each="entry : ${task['resources']}" th:text="${entry.key} + ': ' + ${entry.value}"></li>
+                </ul>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    <a href="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
+</div>
+</body>
+</html>

--- a/LiveSchedClient/src/main/resources/templates/taskDetail.html
+++ b/LiveSchedClient/src/main/resources/templates/taskDetail.html
@@ -7,45 +7,45 @@
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-<div class="container mt-5">
-    <h1>Task Details</h1>
-    <table class="table table-bordered">
-        <tbody>
-        <tr>
-            <th>Task ID</th>
-            <td th:text="${task['taskId']}"></td>
-        </tr>
-        <tr>
-            <th>Task Name</th>
-            <td th:text="${task['taskName']}"></td>
-        </tr>
-        <tr>
-            <th>Priority</th>
-            <td th:text="${task['priority']}"></td>
-        </tr>
-        <tr>
-            <th>Start Time</th>
-            <td th:text="${task['startTime'].substring(0, 16)}"></td>
-        </tr>
-        <tr>
-            <th>End Time</th>
-            <td th:text="${task['endTime'].substring(0, 16)}"></td>
-        </tr>
-        <tr>
-            <th>Location</th>
-            <td th:text="${task['location']['coordinates']}"></td>
-        </tr>
-        <tr>
-            <th>Resources Needed</th>
-            <td>
-                <ul>
-                    <li th:each="entry : ${task['resources']}" th:text="${entry.key} + ': ' + ${entry.value}"></li>
-                </ul>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-    <a href="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
-</div>
+    <div class="container mt-5">
+        <h1>Task Details</h1>
+        <table class="table table-bordered">
+            <tbody>
+            <tr>
+                <th>Task ID</th>
+                <td th:text="${task['taskId']}"></td>
+            </tr>
+            <tr>
+                <th>Task Name</th>
+                <td th:text="${task['taskName']}"></td>
+            </tr>
+            <tr>
+                <th>Priority</th>
+                <td th:text="${task['priority']}"></td>
+            </tr>
+            <tr>
+                <th>Start Time</th>
+                <td th:text="${task['startTime'].substring(0, 16)}"></td>
+            </tr>
+            <tr>
+                <th>End Time</th>
+                <td th:text="${task['endTime'].substring(0, 16)}"></td>
+            </tr>
+            <tr>
+                <th>Location</th>
+                <td th:text="${task['location']['coordinates']}"></td>
+            </tr>
+            <tr>
+                <th>Resources Needed</th>
+                <td>
+                    <ul>
+                        <li th:each="entry : ${task['resources']}" th:text="${entry.key} + ': ' + ${entry.value}"></li>
+                    </ul>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <a href="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
+    </div>
 </body>
 </html>

--- a/citations.txt
+++ b/citations.txt
@@ -10,3 +10,5 @@
 - https://bootstrapshuffle.com/classes/tables/table
 - https://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html
 - https://stackoverflow.com/questions/4632738/how-to-add-hyperlink-to-table-row-tr
+- https://behumblefool.medium.com/spring-boot-resttemplate-patch-request-fix-8b44b16ff2c8
+- https://stackoverflow.com/questions/29447382/resttemplate-patch-request

--- a/citations.txt
+++ b/citations.txt
@@ -8,3 +8,5 @@
 - https://www.baeldung.com/rest-template
 - https://www.baeldung.com/jackson-object-mapper-tutorial
 - https://bootstrapshuffle.com/classes/tables/table
+- https://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html
+- https://stackoverflow.com/questions/4632738/how-to-add-hyperlink-to-table-row-tr


### PR DESCRIPTION
This PR:
- Created taskDetail page to view all details of a task and linked this page to the tasks in the dashboard
- Created addTask page to allow creating a new task and added button for this on the dashboard
- Added methods to use the service's endpoints for the above
- Also added a helper method to format start and end times for better visibility
- Passes checkstyle